### PR TITLE
Fix Apex RGB control + rename Button Fix

### DIFF
--- a/decky-plugin/py_modules/button_fix.py
+++ b/decky-plugin/py_modules/button_fix.py
@@ -1,4 +1,4 @@
-"""Button fix for OneXPlayer Apex on Bazzite.
+"""Button and RGB fix for OneXPlayer Apex on Bazzite.
 
 Patches HHD (Handheld Daemon) by replacing its OXP device files with
 Apex-compatible versions. Uses bundled vanilla/patched file copies instead
@@ -317,7 +317,7 @@ def apply():
     """Apply the Apex button fix by copying patched files. Idempotent."""
     steps = []
 
-    _log_info("=== Button Fix Apply Start ===")
+    _log_info("=== Button and RGB Fix Apply Start ===")
 
     status = is_applied()
     if status.get("applied"):
@@ -396,15 +396,15 @@ def apply():
     if not _restart_hhd(steps):
         return {"success": True, "warning": "Patched but HHD restart may have failed", "steps": steps}
 
-    _log_info("Button fix applied successfully")
-    return {"success": True, "message": "Button fix applied and HHD restarted", "steps": steps}
+    _log_info("Button and RGB fix applied successfully")
+    return {"success": True, "message": "Button and RGB fix applied and HHD restarted", "steps": steps}
 
 
 def revert():
     """Revert the Apex button fix by copying vanilla files back."""
     steps = []
 
-    _log_info("=== Button Fix Revert Start ===")
+    _log_info("=== Button and RGB Fix Revert Start ===")
 
     target_dir = _find_target_dir()
     if not target_dir:
@@ -444,8 +444,8 @@ def revert():
     if not _restart_hhd(steps):
         return {"success": True, "warning": "Reverted but HHD restart may have failed", "steps": steps}
 
-    _log_info("Button fix reverted successfully")
-    return {"success": True, "message": "Button fix reverted and HHD restarted", "steps": steps}
+    _log_info("Button and RGB fix reverted successfully")
+    return {"success": True, "message": "Button and RGB fix reverted and HHD restarted", "steps": steps}
 
 
 if __name__ == "__main__":

--- a/decky-plugin/py_modules/hhd_patches/patched/base.py
+++ b/decky-plugin/py_modules/hhd_patches/patched/base.py
@@ -112,24 +112,14 @@ def plugin_run(
                         )
                     )
                 case "hid_v2":
-                    if dconf.get("apex", False):
-                        found_vendor = bool(
-                            enumerate_unique(
-                                vid=X1_MINI_VID,
-                                pid=X1_MINI_PID,
-                                usage_page=X1_MINI_PAGE,
-                                usage=X1_MINI_USAGE,
-                            )
+                    found_vendor = bool(
+                        enumerate_unique(
+                            vid=XFLY_VID,
+                            pid=XFLY_PID,
+                            usage_page=XFLY_PAGE,
+                            usage=XFLY_USAGE,
                         )
-                    else:
-                        found_vendor = bool(
-                            enumerate_unique(
-                                vid=XFLY_VID,
-                                pid=XFLY_PID,
-                                usage_page=XFLY_PAGE,
-                                usage=XFLY_USAGE,
-                            )
-                        )
+                    )
                 case "hid_v1_g1":
                     found_vendor = bool(
                         enumerate_unique(
@@ -282,13 +272,13 @@ def find_vendor(prepare, turbo, protocol: str | None, secondary: bool, vibration
         vibration=vibration_val,
     )
     if apex:
-        # Apex: vendor HID is 1A86:FE00 (X1_MINI), not 1A2C:B001 (XFLY)
+        # Apex: RGB controller is 1A2C:B001 (XFLY), same as other V2 devices
         # Back paddles handled by firmware remap (back_paddle.py), not intercept
         d_hidraw_v2 = OxpHidrawV2(
-            vid=[X1_MINI_VID],
-            pid=[X1_MINI_PID],
-            usage_page=[X1_MINI_PAGE],
-            usage=[X1_MINI_USAGE],
+            vid=[XFLY_VID],
+            pid=[XFLY_PID],
+            usage_page=[XFLY_PAGE],
+            usage=[XFLY_USAGE],
             turbo=turbo,
             required=True,
         )

--- a/decky-plugin/src/FixesSection.tsx
+++ b/decky-plugin/src/FixesSection.tsx
@@ -218,13 +218,13 @@ export const FixesSection: FC<{
           {/* Button Fix */}
           <PanelSectionRow>
             <ToggleField
-              label="Button Fix"
+              label="Button and RGB Fix"
               description={
                 buttonFix.applied
                   ? `Applied${buttonFix.home_monitor_running ? " · Home active" : ""} (toggle off to revert)`
                   : buttonFix.error
                     ? `Error: ${buttonFix.error}`
-                    : "Not applied"
+                    : "Buttons, paddles, and RGB"
               }
               checked={buttonFix.applied}
               disabled={loading.active === "button"}


### PR DESCRIPTION
## Summary

- **Fix RGB routing**: The Apex has two HID devices — `1A86:FE00` (EC/buttons) and `1A2C:B001` (RGB controller). The patched `base.py` was routing V2 RGB commands to the wrong device (`1A86:FE00` / X1_MINI instead of `1A2C:B001` / XFLY). Confirmed via direct hidraw testing that `1A2C:B001` responds to V2 RGB protocol.
- **Rename "Button Fix" to "Button and RGB Fix"** in the UI and log messages, since the patch now fixes both buttons/paddles and RGB control.

## Changes

### `decky-plugin/py_modules/hhd_patches/patched/base.py`
- `plugin_run`: Removed apex-specific branch in `hid_v2` case that used X1_MINI constants — now always uses XFLY (same as other V2 devices)
- `find_vendor`: Changed apex `if` branch to construct `OxpHidrawV2` with XFLY VID/PID/page/usage instead of X1_MINI

### `decky-plugin/src/FixesSection.tsx`
- Label: "Button Fix" → "Button and RGB Fix"
- Description when not applied: "Not applied" → "Buttons, paddles, and RGB"

### `decky-plugin/py_modules/button_fix.py`
- Updated docstring, log messages, and return messages to say "Button and RGB fix" instead of "Button fix"

## Test plan
- [ ] Apply the fix on an Apex device and verify RGB control works in HHD settings
- [ ] Verify button remapping still works after the change
- [ ] Toggle the fix off and back on — confirm revert/re-apply cycle works
- [ ] Check that the UI shows "Button and RGB Fix" with "Buttons, paddles, and RGB" description

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Latest build:** [OneXPlayer_Apex_Tools.zip](https://github.com/srsholmes/onexplayer-apex-bazzite-fixes/actions/runs/23791580290/artifacts/6196757174) (beefd46)