### PR TITLE
Add support for ONEXPLAYER SUPER X in oxpec driver

### DIFF
--- a/decky-plugin/py_modules/oxpec/build/oxpec.c
+++ b/decky-plugin/py_modules/oxpec/build/oxpec.c
@@ -159,6 +159,13 @@ static const struct dmi_system_id dmi_table[] = {
 	{
 		.matches = {
 			DMI_MATCH(DMI_BOARD_VENDOR, "ONE-NETBOOK"),
+			DMI_EXACT_MATCH(DMI_BOARD_NAME, "ONEXPLAYER SUPER X"),
+		},
+		.driver_data = (void *)oxp_fly,
+	},
+	{
+		.matches = {
+			DMI_MATCH(DMI_BOARD_VENDOR, "ONE-NETBOOK"),
 			DMI_EXACT_MATCH(DMI_BOARD_NAME, "ONEXPLAYER F1"),
 		},
 		.driver_data = (void *)oxp_fly,


### PR DESCRIPTION
The OneXPlayer Super X was not fully recognized, what made it impossible to change the Fan Curve an Charge settings. This also made it so that the fan did not ramp up.